### PR TITLE
Add jenkins ci/cd

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline{
                 checkout scm
             }
         }
-        
+        // TODO lint stage
         stage('Prepare'){
             agent none
             steps{
@@ -27,9 +27,13 @@ pipeline{
                 }
             }
             steps{
+                // TODO implement tests
                 echo 'Testing...'
             }
         }
+
+        // TODO code quality stage
+        
         stage('Build'){
             when{
                 branch 'add-jenkins-ci/cd'
@@ -39,11 +43,13 @@ pipeline{
                     sh 'docker buildx build . --tag dogood-backend:$BUILD_NUMBER --target prod --secret id=env,src=$ENV_FILE'
                 }
             }
+            // TODO push to registry
         }
     }
     post{
         always{
             sh 'docker compose down'
         }
+        // TODO email notification
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,9 @@ pipeline{
         image "node:22-slim"
         label "docker-nodejs"
     }
+    when{
+        branch 'add-jenkins-ci/cd'
+    }
     stages{
         stage 'Checkout Code'{
             steps{
@@ -13,9 +16,6 @@ pipeline{
         stage('Build'){
             steps{
                 echo "Building..."
-                sh "npm install"
-                sh "npx prisma generate"
-                sh "npm run build"
             }
         }
         stage('Test'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline{
     }
     
     stages{
-        stage 'Checkout Code'{
+        stage ('Checkout Code'){
             steps{
                 checkout scm
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,34 +19,27 @@ pipeline{
                 }
             }
         }
-        stage('Build'){
+        stage('Test'){
             agent{
                 docker{
                     image "node:22-slim"
                     args '--network=dev-network'
                 }
             }
+            steps{
+                echo 'Testing...'
+            }
+        }
+        stage('Build'){
             when{
                 branch 'add-jenkins-ci/cd'
             }
             steps{
                withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
-                    sh '''
-                    rm-f .env
-                    cp $ENV_FILE .env
-                    npm install
-                    npx prisma generate
-                    npx prisma migrate dev
-                    '''
+                    sh 'docker buildx build . --tag dogood-backend:$BUILD_NUMBER --target prod --secret id=env,src=$ENV_FILE'
                 }
             }
         }
-        stage('Test'){
-            steps{
-                echo 'Testing...'
-            }
-        }
-        
     }
     post{
         always{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline{
             steps{
                   withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
                     sh '''
+                    rm -f .env
                     cp $ENV_FILE .env
                     docker compose up postgres redis -d    
                     '''
@@ -31,6 +32,7 @@ pipeline{
             steps{
                withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
                     sh '''
+                    rm-f .env
                     cp $ENV_FILE .env
                     npm install
                     npx prisma generate

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,8 @@ pipeline{
             steps{
                   withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
                     sh '''
-                    # cp $ENV_FILE .env
-                    docker compose up postgres redis -d
-                    cat .env      
+                    cp $ENV_FILE .env
+                    docker compose up postgres redis -d    
                     '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,13 @@ pipeline{
         stage('Prepare'){
             agent none
             steps{
-                  sh 'docker compose up postgress-dev redis-dev -d'
+                  withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
+                    sh '''
+                    # cp $ENV_FILE .env
+                    docker compose up postgres redis -d
+                    cat .env      
+                    '''
+                }
             }
         }
         stage('Build'){
@@ -24,10 +30,10 @@ pipeline{
                 branch 'add-jenkins-ci/cd'
             }
             steps{
-                withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
+               withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
                     sh '''
                     cp $ENV_FILE .env
-                    npm install --production
+                    npm install
                     npx prisma generate
                     npx prisma migrate dev
                     '''
@@ -39,10 +45,11 @@ pipeline{
                 echo 'Testing...'
             }
         }
-        post{
+        
+    }
+    post{
         always{
             sh 'docker compose down'
         }
-    }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,31 +1,48 @@
 pipeline{
-    agent 
-    {
-        docker{
-            image "node:22-slim"
-        }
-    }
-    
+    agent any
     stages{
         stage ('Checkout Code'){
             steps{
                 checkout scm
             }
         }
+        
+        stage('Prepare'){
+            agent none
+            steps{
+                  sh 'docker compose up postgress-dev redis-dev -d'
+            }
+        }
         stage('Build'){
+            agent{
+                docker{
+                    image "node:22-slim"
+                    args '--network=dev-network'
+                }
+            }
             when{
                 branch 'add-jenkins-ci/cd'
             }
             steps{
-                echo "Building..."
+                withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {
+                    sh '''
+                    cp $ENV_FILE .env
+                    npm install --production
+                    npx prisma generate
+                    npx prisma migrate dev
+                    '''
+                }
             }
         }
         stage('Test'){
-            agent{label 'tester'}
             steps{
                 echo 'Testing...'
             }
         }
+        post{
+        always{
+            sh 'docker compose down'
+        }
     }
-    
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,12 @@
 pipeline{
-    agent docker{
-        image "node:22-slim"
-        label "docker-nodejs"
+    agent 
+    {
+        docker{
+            image "node:22-slim"
+            label "docker-nodejs"
+        }
     }
-    when{
-        branch 'add-jenkins-ci/cd'
-    }
+    
     stages{
         stage 'Checkout Code'{
             steps{
@@ -13,6 +14,9 @@ pipeline{
             }
         }
         stage('Build'){
+            when{
+                branch 'add-jenkins-ci/cd'
+            }
             steps{
                 echo "Building..."
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,10 +33,9 @@ pipeline{
         }
 
         // TODO code quality stage
-        
         stage('Build'){
             when{
-                branch 'add-jenkins-ci/cd'
+                branch 'release/* staging'
             }
             steps{
                withCredentials([file(credentialsId: 'backend-env', variable: 'ENV_FILE')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 pipeline{
-    agent docker
-    {
+    agent docker{
         image "node:22-slim"
         label "docker-nodejs"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@ pipeline{
     {
         docker{
             image "node:22-slim"
-            label "docker-nodejs"
         }
     }
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,29 @@
+pipeline{
+    agent docker
+    {
+        image "node:22-slim"
+        label "docker-nodejs"
+    }
+    stages{
+        stage 'Checkout Code'{
+            steps{
+                checkout scm
+            }
+        }
+        stage('Build'){
+            steps{
+                echo "Building..."
+                sh "npm install"
+                sh "npx prisma generate"
+                sh "npm run build"
+            }
+        }
+        stage('Test'){
+            agent{label 'tester'}
+            steps{
+                echo 'Testing...'
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
Тут додав невеликий скрипт для CI/CD. Тригериться все в мене локально, потім переставлю на сервер. 
Що треба знати:
 - При пуші на `develop` чи `staging` тригериться CI/CD сервер, і виконується його логіка.
 - Наразі тільки стадія підготовки та білда. Тести будуть, то допушу тести + нотифікація через електронну пошту про стан їх виконання (якщо вийде, то додам ще перевірку якості коду).

Зараз треба, щоб **Jenkinsfile** був на наступних гілках: `develop`, `staging`, і в майбутньому `release/*` чи `main`, якщо робимо через такий flow.  

Власне для чого: щоб сервер міг відслідковувати на них зміни, одразу їх тестувати і надавати статус про стан проєкту (тому, до речі, так часто випитую за тести). 